### PR TITLE
Feature/add activity type

### DIFF
--- a/BrowserActivity/Classes/BrowserActivity.swift
+++ b/BrowserActivity/Classes/BrowserActivity.swift
@@ -45,3 +45,8 @@ public class BrowserActivity: UIActivity {
         return activities
     }
 }
+
+public extension UIActivityType {
+    static let openInGoogleChrome = UIActivityType(rawValue: "com.raxityo.BrowserActivity.openInGoogleChrome")
+    static let openInSafari = UIActivityType(rawValue: "com.raxityo.BrowserActivity.openInSafari")
+}                                                       

--- a/BrowserActivity/Classes/GoogleChromeActivity.swift
+++ b/BrowserActivity/Classes/GoogleChromeActivity.swift
@@ -1,5 +1,5 @@
 //
-//  GoogelChromeActivity.swift
+//  GoogleChromeActivity.swift
 //  The Tech Time
 //
 //  Created by Rakshit Majithiya on 1/11/17.

--- a/BrowserActivity/Classes/GoogleChromeActivity.swift
+++ b/BrowserActivity/Classes/GoogleChromeActivity.swift
@@ -35,4 +35,8 @@ public class GoogleChromeActivity: BrowserActivity {
             return UIImage(named: "icon_chrome", in: Bundle(for: self.classForCoder), compatibleWith: nil)
         }
     }
+
+    override public var activityType: UIActivityType {
+        return UIActivityType.openInGoogleChrome
+    }
 }

--- a/BrowserActivity/Classes/SafariActivity.swift
+++ b/BrowserActivity/Classes/SafariActivity.swift
@@ -21,4 +21,8 @@ public class SafariActivity: BrowserActivity {
             return UIImage(named: "icon_safari", in: Bundle(for: self.classForCoder), compatibleWith: nil)
         }
     }
+    
+    override public var activityType: UIActivityType {
+        return UIActivityType.openInSafari
+    }
 }

--- a/BrowserActivity/Classes/SafariActivity.swift
+++ b/BrowserActivity/Classes/SafariActivity.swift
@@ -1,5 +1,5 @@
 //
-//  GoogleChromeActivity.swift
+//  SafariActivity.swift
 //  The Tech Time
 //
 //  Created by Rakshit Majithiya on 1/11/17.


### PR DESCRIPTION
Hi

Thanks for making that useful library.

I send you two fix/features PR.

1. Add ActivityType
2. Fix comments

## 1. Add ActivityType

### Motivation 

I want to handle process by each type of item source (in UIActivityItemSource), but you does not specified any activityType.

### My Solution/Proposal

1. Add `openInGoogleChrome` and `openInSafari` to `UIActivityType` using `extension` in `BrowserActivity.swift`
2. Override activityType properties in `GoogleChromeActivity.swift` and `SafariActivity.swift`

Please see this:  https://github.com/raxityo/BrowserActivity/commit/df1bbefaaf958f2ea56d498500efe9cc4b4d93af

## 2. Fix comments

It is easy to read. please see this: 

https://github.com/raxityo/BrowserActivity/commit/09237a84a7ef7dd90f5e8a6cb9c0d2f5c6b831a5


regards, 